### PR TITLE
Install npm packages before building & bundling

### DIFF
--- a/Scripts/Provision-GDPRActivityHub.ps1
+++ b/Scripts/Provision-GDPRActivityHub.ps1
@@ -112,6 +112,7 @@ try
             Write-Host "Building SPFx package and bundling"
             Push-Location ..\GDPRStarterKit
 
+            npm install
             $cdnSiteAssetsFullUrl = "https://publiccdn.sharepointonline.com/" + $spoTenantName + "/sites/" + $CDNSiteName + "/" + $CDNLibraryName + "/GDPRActivityHub"
             & gulp update-manifest --cdnpath "$cdnSiteAssetsFullUrl"
             & gulp clean


### PR DESCRIPTION
I would get the following error because the npm packages were not downloaded in the "GDPRStarterKit" folder.


```
Building SPFx package and bundling
[10:54:17] Local gulp not found in C:\p\gdpr\GDPRStarterKit
[10:54:17] Try running: npm install gulp
[10:54:17] Local gulp not found in C:\p\gdpr\GDPRStarterKit
[10:54:17] Try running: npm install gulp
[10:54:18] Local gulp not found in C:\p\gdpr\GDPRStarterKit
[10:54:18] Try running: npm install gulp
[10:54:18] Local gulp not found in C:\p\gdpr\GDPRStarterKit
[10:54:18] Try running: npm install gulp
Uploading SPFx assets to the CDN
```
