### PR TITLE
FileCreationInformation conflict

### DIFF
--- a/Scripts/Provision-GDPRActivityHub.ps1
+++ b/Scripts/Provision-GDPRActivityHub.ps1
@@ -127,17 +127,11 @@ try
             $context = Get-PnPContext
             $context.Load($packageFolder)
             Execute-PnPQuery
-
+	    
+	    $cdnSiteAssetsUploadUrl = $CDNLibraryName + "/GDPRActivityHub"
             foreach ($file in (dir ..\GDPRStarterKit\temp\deploy -File)) 
             {
-                $fileStream = New-Object IO.FileStream($file.FullName, [System.IO.FileMode]::Open)
-                $fileCreationInfo = New-Object Microsoft.SharePoint.Client.FileCreationInformation
-                $fileCreationInfo.Overwrite = $true
-                $fileCreationInfo.ContentStream = $fileStream
-                $fileCreationInfo.URL = $file
-                $upload = $packageFolder.Files.Add($fileCreationInfo)
-                $context.Load($upload)
-                Execute-PnPQuery
+	    	$uploadedFile = Add-PnPFile -Path $file.FullName -Folder $cdnSiteAssetsUploadUrl
             }
 
             # Configure the CDN at the tenant level


### PR DESCRIPTION
Fix for the following exception:

```
Exception occurred!
Exception Type: System.Management.Automation.MethodException
Exception Message: Cannot convert argument "parameters", with value: "Microsoft.SharePoint.Client.FileCreationInformation", for "Add" to type "Microsoft.SharePoint.Client.FileCreationInformation": "Cannot convert the "Microsoft.SharePoint.Client.FileCreationInformation" value of type "Microsoft.SharePoint.Client.FileCreationInformation" to type "Microsoft.SharePoint.Client.FileCreationInformation"."
```
I'm assuming somehow the PnP PowerShell DLL's are getting conflicted with local/GAC DLL's when using the FileCreationInformation class. Solution is to use the Add-PnPFile cmdlet.

Also reported in issue [20](https://github.com/SharePoint/sp-dev-gdpr-activity-hub/issues/20)